### PR TITLE
修复创建角色卡时出现的数组匹配问题

### DIFF
--- a/src/services/workflows/architecture-workflow.ts
+++ b/src/services/workflows/architecture-workflow.ts
@@ -215,7 +215,18 @@ export function createCharacterExtractSteps(_projectPath: string, characterDynam
 
         const cleanedCards = stripThinkingTags(fullContent)
         const jsonStr = cleanedCards.replace(/```json?\n?/g, '').replace(/```/g, '').trim()
-        const parsedCards = JSON.parse(jsonStr) as Array<Record<string, unknown>>
+        const parsedData = JSON.parse(jsonStr)
+
+        // 兼容两种格式：直接数组 或 { characters: [...] }
+        const parsedCards: Array<Record<string, unknown>> = Array.isArray(parsedData)
+          ? parsedData
+          : (parsedData && typeof parsedData === 'object' && Array.isArray((parsedData as Record<string, unknown>).characters))
+            ? (parsedData as Record<string, unknown>).characters as Array<Record<string, unknown>>
+            : []
+
+        if (parsedCards.length === 0) {
+          throw new Error('AI 返回的角色数据格式不正确，未提取到有效角色')
+        }
 
         // 构建角色卡数据列表
         const validRoles = ['protagonist', 'antagonist', 'supporting', 'minor']


### PR DESCRIPTION
修复创建角色卡时出现的数组匹配问题。
AI 返回的 JSON 格式是一个**对象**而不是**数组**：

```json
{
  "characters": [
    { "name": "宗河达", ... },
    { "name": "墨璃", ... },
    ...
  ]
}
```

但是代码期望的是**直接的数组格式**：

```json
[
  { "name": "宗河达", ... },
  { "name": "墨璃", ... },
  ...
]
```

## 问题根源

这**既是代码问题，也是 AI 的问题**：

### 1. **Prompt 模板问题**
[prompt-templates.ts](file:///d:/GitHub/vela/src/services/prompt-templates.ts#L962-L989) 中明确要求 AI 返回 JSON 数组：

```typescript
【输出格式（JSON 数组）】
[
  {
    "name": "角色名",
    ...
  }
]
```

但 AI 实际返回了一个包含 `characters` 字段的对象。

### 2. **代码缺少容错处理**
[architecture-workflow.ts](file:///d:/GitHub/vela/src/services/workflows/architecture-workflow.ts#L216-L223) 没有处理 AI 返回不同格式的情况。

**修复方案**：
1. **添加格式兼容逻辑**：现在代码会自动检测并处理两种格式：
   - 直接数组：`[{...}, {...}]`
   - 对象包装：`{ "characters": [{...}, {...}] }`

2. **添加空值检查**：如果两种格式都不匹配或提取不到角色，会抛出明确的错误提示。

修改位置：[architecture-workflow.ts](file:///d:/GitHub/vela/src/services/workflows/architecture-workflow.ts#L216-L238)
