### PR TITLE
fix: API URL 构建错误导致 404 + 角色卡提取失败

### DIFF
--- a/electron/embedding.ts
+++ b/electron/embedding.ts
@@ -16,7 +16,16 @@ export async function embedOpenAI(
   model: { baseUrl: string; apiKey: string; modelName?: string },
 ): Promise<number[][]> {
   const embeddingModel = model.modelName || 'text-embedding-3-small'
-  const url = model.baseUrl.replace(/\/$/, '') + '/embeddings'
+  // 智能构建 embedding URL，兼容多种 baseUrl 格式
+  const base = model.baseUrl.replace(/\/$/, '')
+  let url: string
+  if (base.endsWith('/embeddings')) {
+    url = base
+  } else if (/\/v\d+$/.test(base)) {
+    url = `${base}/embeddings`
+  } else {
+    url = `${base}/v1/embeddings`
+  }
   const res = await fetch(url, {
     method: 'POST',
     headers: {

--- a/electron/llm/openai-provider.ts
+++ b/electron/llm/openai-provider.ts
@@ -4,11 +4,19 @@ import { ModelProfile } from '../../src/shared/ipc-channels'
 export class OpenAIProvider implements ILLMProvider {
   private buildUrl(baseUrl: string): string {
     const base = baseUrl.replace(/\/$/, '')
-    // 如果 baseUrl 已经带了完整 /v1/chat 路径，直接用
-    if (base.endsWith('/v1/chat')) {
+    // 已包含完整路径
+    if (base.endsWith('/chat/completions')) {
+      return base
+    }
+    // 已包含 /chat 但缺 /completions
+    if (base.endsWith('/chat')) {
       return `${base}/completions`
     }
-    // 否则补全完整路径
+    // 已包含版本号路径（/v1, /v4 等），直接补全 chat/completions
+    if (/\/v\d+$/.test(base)) {
+      return `${base}/chat/completions`
+    }
+    // 无版本号路径，补全 /v1/chat/completions
     return `${base}/v1/chat/completions`
   }
 

--- a/src/services/prompt-templates.ts
+++ b/src/services/prompt-templates.ts
@@ -976,34 +976,37 @@ severity 取值：error=严重矛盾强烈建议修复, warning=轻微不一致�
 4. role 字段仅限以下取值：protagonist（主角）、antagonist（反派）、supporting（配角）、minor（龙套）。
 5. currentState 是角色的初始状态（故事开始时），updatedAtChapter 固定为 0。
 
-【输出格式（JSON 数组）】
-[
-  {
-    "name": "角色名",
-    "role": "protagonist",
-    "gender": "性别",
-    "age": "年龄或年龄段",
-    "appearance": "外貌特征",
-    "personality": "性格特点",
-    "background": "背景故事",
-    "abilities": "能力/技能/修为",
-    "motivation": "核心动机与渴望",
-    "relationships": "与其他角色的关系",
-    "arc": "预期的角色弧光/成长轨迹",
-    "notes": "其他补充说明",
-    "currentState": {
-      "location": "初始位置",
-      "powerLevel": "初始境界/能力等级",
-      "physicalState": "初始身体状态",
-      "mentalState": "初始心理状态",
-      "keyItems": "初始持有道具",
-      "recentEvents": "故事开始前的背景事件",
-      "updatedAtChapter": 0
+【输出格式】
+必须返回一个 JSON 对象，格式如下（characters 数组包含所有角色）：
+{
+  "characters": [
+    {
+      "name": "角色名",
+      "role": "protagonist",
+      "gender": "性别",
+      "age": "年龄或年龄段",
+      "appearance": "外貌特征",
+      "personality": "性格特点",
+      "background": "背景故事",
+      "abilities": "能力/技能/修为",
+      "motivation": "核心动机与渴望",
+      "relationships": "与其他角色的关系",
+      "arc": "预期的角色弧光/成长轨迹",
+      "notes": "其他补充说明",
+      "currentState": {
+        "location": "初始位置",
+        "powerLevel": "初始境界/能力等级",
+        "physicalState": "初始身体状态",
+        "mentalState": "初始心理状态",
+        "keyItems": "初始持有道具",
+        "recentEvents": "故事开始前的背景事件",
+        "updatedAtChapter": 0
+      }
     }
-  }
-]
+  ]
+}
 
-如果图谱中没有任何可提取的角色，返回空数组 []。`,
+如果图谱中没有任何可提取的角色，返回 {"characters": []}。`,
   },
 
   // ================================================================

--- a/src/services/workflows/architecture-workflow.ts
+++ b/src/services/workflows/architecture-workflow.ts
@@ -217,15 +217,31 @@ export function createCharacterExtractSteps(_projectPath: string, characterDynam
         const jsonStr = cleanedCards.replace(/```json?\n?/g, '').replace(/```/g, '').trim()
         const parsedData = JSON.parse(jsonStr)
 
-        // 兼容两种格式：直接数组 或 { characters: [...] }
-        const parsedCards: Array<Record<string, unknown>> = Array.isArray(parsedData)
-          ? parsedData
-          : (parsedData && typeof parsedData === 'object' && Array.isArray((parsedData as Record<string, unknown>).characters))
-            ? (parsedData as Record<string, unknown>).characters as Array<Record<string, unknown>>
-            : []
+        // 兼容多种格式：直接数组、{ characters: [...] }、或其他包含数组的对象
+        let parsedCards: Array<Record<string, unknown>> = []
+        if (Array.isArray(parsedData)) {
+          // 直接返回数组 [...]
+          parsedCards = parsedData as Array<Record<string, unknown>>
+        } else if (parsedData && typeof parsedData === 'object') {
+          const obj = parsedData as Record<string, unknown>
+          // 优先查找 characters 字段
+          if (Array.isArray(obj.characters)) {
+            parsedCards = obj.characters as Array<Record<string, unknown>>
+          } else {
+            // 回退：查找对象中第一个包含对象的数组字段
+            for (const value of Object.values(obj)) {
+              if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'object') {
+                parsedCards = value as Array<Record<string, unknown>>
+                break
+              }
+            }
+          }
+        }
 
         if (parsedCards.length === 0) {
-          throw new Error('AI 返回的角色数据格式不正确，未提取到有效角色')
+          // 输出原始内容前 500 字符用于调试
+          const preview = cleanedCards.slice(0, 500)
+          throw new Error(`AI 返回的角色数据格式不正确，未提取到有效角色。原始内容预览: ${preview}`)
         }
 
         // 构建角色卡数据列表


### PR DESCRIPTION
## 修复 API URL 构建和角色卡提取两个 Bug

### Bug 1: API URL 构建错误导致 404 (openai-provider.ts + embedding.ts)

#### 问题
`buildUrl` 函数在 `baseUrl` 以 `/v1` 结尾时会重复拼接路径，导致请求路径变成 `/v1/v1/chat/completions`，服务器返回 404 Not Found。

#### 复现
配置模型时 baseUrl 填写 `https://api.proxy.com/v1`（很多代理服务默认带 `/v1`），点击「测试连接」报错：
```
❌ 连接失败: API 调用失败 (404): ... 404 Not Found ... openresty ...
```

#### 修复
智能识别 4 种 baseUrl 格式：

| baseUrl 输入 | 修复前（错误） | 修复后（正确） |
|---|---|---|
| `https://api.xxx.com` | `.../v1/chat/completions` | `.../v1/chat/completions` |
| `https://api.xxx.com/v1` | `.../v1/v1/chat/completions` ❌ | `.../v1/chat/completions` |
| `https://api.xxx.com/v1/chat` | `.../v1/chat/completions` | `.../v1/chat/completions` |
| `https://open.bigmodel.cn/api/paas/v4` | `.../v4/v1/chat/completions` ❌ | `.../v4/chat/completions` |

同时修复了 `embedding.ts` 的 URL 拼接问题（之前直接拼 `/embeddings`，缺少 `/v1` 前缀）。

---

### Bug 2: 角色卡提取失败 (prompt-templates.ts + architecture-workflow.ts)

#### 问题
`extract_initial_characters` 步骤始终报错「AI 返回的角色数据格式不正确，未提取到有效角色」。

#### 根因
代码设置了 `responseFormat: { type: 'json_object' }`，强制 API 返回 JSON 对象 `{...}`。但 prompt 模板却要求 AI 返回 JSON 数组 `[...]`。这造成冲突——AI 被迫返回对象，但用了不可预测的 key 来包裹数组，解析失败。

#### 修复
1. **prompt 模板**：改为明确要求返回 `{"characters": [...]}` 对象格式，与 `json_object` 约束一致
2. **解析逻辑**：更健壮地查找角色数组（优先 `characters` key，回退扫描第一个对象数组）
3. **错误信息**：失败时输出原始内容预览（前 500 字符），方便调试

---

### 测试
两个修复均已在本地运行验证通过。
