### PR TITLE
fix(i18n): remove hardcoded Chinese fallback in ReviewReport

### DIFF
--- a/src/components/editor/ReviewReport.tsx
+++ b/src/components/editor/ReviewReport.tsx
@@ -144,35 +144,29 @@ function parseLegacyReport(text: string, defaultCategory: string): { issues: Rev
 }
 
 // ===== 视觉配置 =====
+// Note: Labels are handled via i18n (see severityLabels below).
+// This constant only holds visual properties (emoji, colors).
 
 const SEVERITY_META: Record<ReviewIssue['severity'], {
-  label: string
   emoji: string
-  actionLabel: string
   colorClass: string
   bgClass: string
   borderClass: string
 }> = {
   error: {
-    label: '严重问题',
     emoji: '🔴',
-    actionLabel: '强烈建议修复',
     colorClass: 'text-red-400',
     bgClass: 'bg-red-500/10',
     borderClass: 'border-red-500/30',
   },
   warning: {
-    label: '改进建议',
     emoji: '🟡',
-    actionLabel: '建议酌情修复',
     colorClass: 'text-yellow-400',
     bgClass: 'bg-yellow-500/10',
     borderClass: 'border-yellow-500/30',
   },
   pass: {
-    label: '检查通过',
     emoji: '🟢',
-    actionLabel: '无需处理',
     colorClass: 'text-green-400',
     bgClass: 'bg-green-500/10',
     borderClass: 'border-green-500/30',
@@ -201,8 +195,8 @@ export default function ReviewReport({ reportText, draftPath, chapterNumber, cha
   const warningCount = issues.filter((i) => i.severity === 'warning').length
   const passCount = issues.filter((i) => i.severity === 'pass').length
 
-  // Translated severity labels
-  const severityLabels: Record<string, { label: string; actionLabel: string }> = {
+  // Translated severity labels (source of truth for all language display)
+  const severityLabels: Record<ReviewIssue['severity'], { label: string; actionLabel: string }> = {
     error: { label: t('reviewReport.severity.error.label'), actionLabel: t('reviewReport.severity.error.actionLabel') },
     warning: { label: t('reviewReport.severity.warning.label'), actionLabel: t('reviewReport.severity.warning.actionLabel') },
     pass: { label: t('reviewReport.severity.pass.label'), actionLabel: t('reviewReport.severity.pass.actionLabel') },
@@ -304,16 +298,17 @@ export default function ReviewReport({ reportText, draftPath, chapterNumber, cha
             <div className="font-medium text-[var(--color-text)] mb-1.5">{t('reviewReport.colorLegendTitle')}</div>
             {(['error', 'warning', 'pass'] as const).map(sev => {
               const meta = SEVERITY_META[sev]
+              const label = severityLabels[sev]
               return (
                 <div key={sev} className="flex items-center gap-2">
                   <span className={cn(
                     'inline-flex items-center gap-1 px-2 py-0.5 rounded',
                     meta.bgClass, meta.colorClass
                   )}>
-                    {meta.emoji} {severityLabels[sev]?.label ?? meta.label}
+                    {meta.emoji} {label.label}
                   </span>
                   <span style={{ color: 'var(--color-text-secondary)' }}>
-                    — {severityLabels[sev]?.actionLabel ?? meta.actionLabel}
+                    — {label.actionLabel}
                   </span>
                 </div>
               )
@@ -353,7 +348,7 @@ export default function ReviewReport({ reportText, draftPath, chapterNumber, cha
                 <div className="space-y-1.5 pl-1">
                   {items.map((item, i) => {
                     const sevMeta = SEVERITY_META[item.severity]
-                    const translatedMeta = severityLabels[item.severity] ?? sevMeta
+                    const label = severityLabels[item.severity]
                     return (
                       <div
                         key={i}
@@ -369,7 +364,7 @@ export default function ReviewReport({ reportText, draftPath, chapterNumber, cha
                             <span
                               className={cn('ml-2 text-[0.65rem] opacity-70', sevMeta.colorClass)}
                             >
-                              [{translatedMeta.actionLabel}]
+                              [{label.actionLabel}]
                             </span>
                           </div>
                         </div>


### PR DESCRIPTION
## Description
This PR fixes hardcoded Chinese fallback strings in `ReviewReport.tsx`. Even though the component uses `t()` for translations, the fallback chains (`?? meta.label`) meant that hardcoded Chinese values in `SEVERITY_META` could leak into English/Russian UIs.

## Root Cause

```typescript
// BEFORE: Chinese hardcoded as fallback in SEVERITY_META
const SEVERITY_META = {
  error: {
    label: '严重问题',           // ❌ Chinese fallback
    actionLabel: '强烈建议修复', // ❌ Chinese fallback
    emoji: '🔴',
    // ... visual props
  },
  // ...
}

// JSX with fallback chain that leaks Chinese
{severityLabels[sev]?.label ?? meta.label}
//                              ^^^^^^^^^^^ Falls back to Chinese!
```
## Changes
src/components/editor/ReviewReport.tsx

- Removed label and actionLabel properties from SEVERITY_META (now visual props only: emoji, colors, classes)
- Removed fallback chains (?? meta.label, ?? sevMeta) in JSX rendering
- All severity labels now purely sourced from severityLabels (i18n)
- Updated TypeScript type for SEVERITY_META to reflect visual-only properties


## Locale Files

✅ No changes needed — all required translation keys already exist in en/, zh-CN/, ru/ locale files:

- reviewReport.severity.error.label / .actionLabel
- reviewReport.severity.warning.label / .actionLabel
- reviewReport.severity.pass.label / .actionLabel


## Testing

 - Chinese UI → all severity labels in Chinese ✅
 - English UI → all severity labels in English ✅
 - Russian UI → all severity labels in Russian ✅
 - No mixed-language display in any scenario
 - Language switching works correctly
 - Color Legend displays properly in all languages
 - pnpm dev runs without errors

## Scope

This PR only addresses ReviewReport.tsx. Other components in the codebase may have similar patterns (hardcoded Chinese as fallback or direct hardcoded strings) that can be addressed in follow-up PRs.

## Design Principle

Following the "no mixed language" principle — user's UI selection should be strictly honored without silent fallback to a different language. If a translation is missing, that's a bug to fix in locale files, not something to mask with hardcoded fallback in another language.

## Related

Follow-up to #23 (NovelConfigEditor i18n fix). Same cleanup pattern can be applied to other components with similar fallback chains.


